### PR TITLE
Add support for decimal precision and range options

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,12 @@ var MysqlDriver = Base.extend({
     var escapedName = util.format('`%s`', name),
         t = this.mapDataType(spec),
         len;
-    if(spec.type !== type.TEXT && spec.type !== type.BLOB) {
+    if(spec.type === type.DECIMAL) {
+       if(spec.precision && spec.scale){
+         len = '(' + spec.precision + ',' + spec.scale + ')';
+       }
+    }
+    else if(spec.type !== type.TEXT && spec.type !== type.BLOB) {
       len = spec.length ? util.format('(%s)', spec.length) : '';
       if (t === 'VARCHAR' && len === '') {
         len = '(255)';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "db-migrate-mysql",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "db-migrate mysql driver",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "db-migrate-mysql",
-  "version": "1.1.7",
+  "version": "1.1.6",
   "description": "db-migrate mysql driver",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Example of column definition:

```
balance: { type: 'decimal', precision: "9", scale: "2", notNull: true }
```

issue #3 
