### PR TITLE
precision support for current_timestamp

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,8 +126,8 @@ var MysqlDriver = Base.extend({
       constraint.push('ROW_FORMAT=\'' + spec.rowFormat + '\'')
     }
 
-    if (spec.onUpdate && spec.onUpdate === 'CURRENT_TIMESTAMP') {
-      constraint.push('ON UPDATE CURRENT_TIMESTAMP')
+    if (spec.onUpdate && spec.onUpdate.startsWith('CURRENT_TIMESTAMP')) {
+      constraint.push('ON UPDATE ' + spec.onUpdate)
     }
 
     if (spec.null || spec.notNull === false) {
@@ -138,7 +138,7 @@ var MysqlDriver = Base.extend({
       constraint.push('DEFAULT');
 
       if (typeof spec.defaultValue === 'string'){
-        if(spec.defaultValue === 'CURRENT_TIMESTAMP') {
+        if(spec.defaultValue.startsWith('CURRENT_TIMESTAMP')) {
           constraint.push(spec.defaultValue);
         }
         else {

--- a/test/mysql_test.js
+++ b/test/mysql_test.js
@@ -48,7 +48,8 @@ vows.describe('mysql').addBatch({
         dt: dataType.DATE_TIME,
         ts: dataType.TIMESTAMP,
         bin: dataType.BINARY,
-        bl: { type: dataType.BOOLEAN, defaultValue: false }
+        bl: { type: dataType.BOOLEAN, defaultValue: false },
+        ct: { type: dataType.DATE_TIME, length: 3, defaultValue: 'CURRENT_TIMESTAMP(3)', onUpdate: 'CURRENT_TIMESTAMP(3)' }
       }, this.callback);
     },
 
@@ -82,9 +83,9 @@ vows.describe('mysql').addBatch({
         }.bind(this));
       },
 
-      'with 10 columns': function(err, columns) {
+      'with 11 columns': function(err, columns) {
         assert.isNotNull(columns);
-        assert.equal(columns.length, 10);
+        assert.equal(columns.length, 11);
       },
 
       'that has integer id column that is primary key, non-nullable, and auto increments': function(err, columns) {
@@ -148,7 +149,20 @@ vows.describe('mysql').addBatch({
         assert.equal(column.getDataType(), 'TINYINT');
         assert.equal(column.isNullable(), true);
         assert.equal(column.getDefaultValue(), 0);
+      },
+
+      'that has ct column with current timestamp with precision 3 as defaultValue': function(err, columns) {
+        var column = findByName(columns, 'ct');
+        assert.equal(column.getDataType(), 'DATETIME');
+        assert.equal(column.getDefaultValue(), 'CURRENT_TIMESTAMP(3)');
+      },
+
+      'that has ct column with current timestamp with as onUpdate value': function(err, columns) {
+        var column = findByName(columns, 'ct');
+        assert.equal(column.getDataType(), 'DATETIME');
+        assert.equal(column.meta.extra, 'on update CURRENT_TIMESTAMP')
       }
+
     }
   }
 }).addBatch({


### PR DESCRIPTION
We tend use `CURRENT_TIMESTAMP` with precision support (`CURRENT_TIMESTAMP(3)`).

So far I've just created an extra query to change the column's default to `CURRENT_TIMESTAMP(3)` because `db-migrate-mysql` did not support this. If you use `CURRENT_TIMESTAMP(3)` as `onUpdate` or as `defaultValue` you end up `DEFAULT "CURRENT_TIMESTAMP(3)"` (the extra quotes shouldn't be there).

So I found (I think) a pretty neat way of handling this.

But since there are no tests for `onUpdate` and `defaultValue` with `CURRENT_TIMESTAMP`, can you help what should be the right way to have those?