### PR TITLE
feat(comment): Add comment spec for columns

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,6 +151,10 @@ var MysqlDriver = Base.extend({
       }
     }
 
+    if (spec.comment) {
+        constraint.push('COMMENT \'' + spec.comment + '\'')
+    }
+
     if (spec.foreignKey) {
 
       cb = this.bindForeignKey(tableName, columnName, spec.foreignKey);


### PR DESCRIPTION
Columns can have comment if the 'comment' property is set in the column definition.

Relates to db-migrate/node-db-migrate#558