### PR TITLE
Allow specifying migration tables with their database name prepended

### DIFF
--- a/index.js
+++ b/index.js
@@ -304,12 +304,12 @@ var MysqlDriver = Base.extend({
 
   addMigrationRecord: function (name, callback) {
     var formattedDate = moment(new Date()).format('YYYY-MM-DD HH:mm:ss');
-    this.runSql('INSERT INTO `' + internals.migrationTable + '` (`name`, `run_on`) VALUES (?, ?)', [name, formattedDate], callback);
+    this.runSql('INSERT INTO ' + internals.migrationTable + ' (`name`, `run_on`) VALUES (?, ?)', [name, formattedDate], callback);
   },
 
   addSeedRecord: function (name, callback) {
     var formattedDate = moment(new Date()).format('YYYY-MM-DD HH:mm:ss');
-    this.runSql('INSERT INTO `' + internals.seedTable + '` (`name`, `run_on`) VALUES (?, ?)', [name, formattedDate], callback);
+    this.runSql('INSERT INTO ' + internals.seedTable + ' (`name`, `run_on`) VALUES (?, ?)', [name, formattedDate], callback);
   },
 
   addForeignKey: function(tableName, referencedTableName, keyName, fieldMapping, rules, callback) {


### PR DESCRIPTION
We have a mysql host with multiple different databases that are covered by the same migrations, any of them can be the active one after the last migration, so the service needs to know exactly which database/table combination to store the migrations in. This is hard with a name surrounded by `.