### PR TITLE
Add character set and collation to column spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,14 @@ const MysqlDriver = Base.extend({
       constraint.push('UNSIGNED');
     }
 
+    if (spec.characterSet) {
+      constraint.push(`CHARACTER SET ${spec.characterSet}`);
+    }
+
+    if (spec.collation) {
+      constraint.push(`COLLATE ${spec.collation}`);
+    }
+
     if (spec.primaryKey) {
       if (!options || options.emitPrimaryKey) {
         constraint.push('PRIMARY KEY');


### PR DESCRIPTION
## Context
This change allows to define `CHARACTER SET` and `COLLATE` for an individual column. This is useful if you want certain values to be stored in ascii rather than utf8.

## Caveats 
- This change will apply to MySQL only. This approach can be replicated for other SQL databases.
- Writing a unit test requires a PR to `db-meta` have it return the character set and collation. Updating the documentation requires a PR to `english-docs`. It is surprisingly high friction to contribute to this library due to how fragmented it is :(