### PR TITLE
fix: Workaround for "Ignoring invalid configuration option passed to Connection: driver"

### DIFF
--- a/index.js
+++ b/index.js
@@ -500,6 +500,7 @@ function dummy () {
 
 exports.connect = function (config, intern, callback) {
   let db;
+  delete config.driver;
 
   internals = intern;
   log = internals.mod.log;


### PR DESCRIPTION
Workaround for the warning in #33 .